### PR TITLE
Builders eda change

### DIFF
--- a/_index.yml
+++ b/_index.yml
@@ -33,7 +33,7 @@ product-family:
     - title: "EDA"
       icon: ./media/icon-builders.png 
       url: ../workload-eda/index.html
-      summary: "Optimize FSx for ONTAP across multiple file systems to boost performance and reduce operational costs through automated storage parameter management."
+      summary: "Optimize FSx for ONTAP performance and costs across multiple file systems with automated storage management."
       tags: all,workload
     - title: "Databases"
       icon: ./media/icon-database.png

--- a/project.yml
+++ b/project.yml
@@ -1,6 +1,6 @@
 settings:
   name: NetApp Workload Factory
-  search: workload-setup-admin,workload-fsx-ontap,workload-databases,workload-vmware,workload-genai,workload-builders,workload-eda, workload-relnotes
+  search: workload-setup-admin,workload-fsx-ontap,workload-databases,workload-vmware,workload-genai,workload-eda,workload-eda, workload-relnotes
   internal:
     pdf_enabled: false
   prod:

--- a/project.yml
+++ b/project.yml
@@ -1,6 +1,6 @@
 settings:
   name: NetApp Workload Factory
-  search: workload-setup-admin,workload-fsx-ontap,workload-databases,workload-vmware,workload-genai,workload-eda,workload-eda, workload-relnotes
+  search: workload-setup-admin,workload-fsx-ontap,workload-databases,workload-vmware,workload-genai,workload-eda,workload-relnotes
   internal:
     pdf_enabled: false
   prod:


### PR DESCRIPTION
This pull request updates references to the EDA workload throughout the configuration files to improve accuracy and consistency. The changes ensure that the EDA workload is correctly linked and described in navigation and search settings.

Navigation and search updates:

* Updated the `search` field in `project.yml` to reference `workload-eda` instead of `workload-builders`, ensuring the EDA workload is discoverable in search.
* Modified the EDA workload entry in `_index.yml` to point to the correct URL (`../workload-eda/index.html`) and improved the summary for clarity and conciseness.